### PR TITLE
panqc is now on Bioconda + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![Static Badge](https://img.shields.io/badge/language-Python_3-blue)
+[![Bioconda](https://img.shields.io/conda/vn/bioconda/panqc.svg?label=Bioconda)](https://bioconda.github.io/recipes/panqc/README.html)
 <!---[![Build Status]()]()
 [![github release version]()]()
 [![DOI]()]()
@@ -56,7 +57,10 @@ pip install .
 ```
 
 ### `conda`
->🚧 Check back soon 🚧
+
+```
+conda install bioconda::panqc
+```
 
 
 


### PR DESCRIPTION
Hi,

I’ve added a Bioconda recipe for panqc, and it’s now available there.

Installable via:
`
conda install -c bioconda panqc
`

I also updated the README to include this as an installation option. 

The main reason for doing this was to integrate panqc into Galaxy, where Bioconda packaging makes dependency management much smoother and keeps environments reproducible.